### PR TITLE
MySql: Handle time as strings

### DIFF
--- a/src/main/java/com/upsolver/datasources/jdbc/querybuilders/MysqlQueryDialect.java
+++ b/src/main/java/com/upsolver/datasources/jdbc/querybuilders/MysqlQueryDialect.java
@@ -1,0 +1,24 @@
+package com.upsolver.datasources.jdbc.querybuilders;
+
+import com.upsolver.datasources.jdbc.utils.ThrowingBiFunction;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TimeZone;
+
+public class MysqlQueryDialect extends DefaultQueryDialect {
+
+    protected static final Map<Integer, ThrowingBiFunction<ResultSet, Integer, Object, SQLException>> additionalGetter = new HashMap<>();
+
+    static {
+        additionalGetter.put(Types.TIME, getString);
+    }
+
+    public MysqlQueryDialect(boolean keepType) {
+        super(keepType, additionalGetter);
+    }
+}

--- a/src/main/java/com/upsolver/datasources/jdbc/querybuilders/QueryDialectProvider.java
+++ b/src/main/java/com/upsolver/datasources/jdbc/querybuilders/QueryDialectProvider.java
@@ -16,6 +16,8 @@ public class QueryDialectProvider {
             return new PostgreSqlQueryDialect(keepTypes);
         } else if (connStr.startsWith("jdbc:snowflake")) {
             return new SnowflakeQueryDialect(keepTypes);
+        } else if (connStr.startsWith("jdbc:mysql")) {
+            new MysqlQueryDialect(keepTypes);
         }
         return new DefaultQueryDialect(keepTypes, Collections.emptyMap());
     }


### PR DESCRIPTION
This is needed since sometimes mysql times contain durations and not clock-time and you can't read them as times. 


This results in errors like: 

> The value '-5:0:0' is an invalid TIME value. JDBC Time objects represent a wall-clock time and not a duration as MySQL treats them. If you are treating this type as a duration, consider retrieving this value as a string and dealing with it according to your requirements.